### PR TITLE
Augment model with attributes through mixins

### DIFF
--- a/spec/mixin_spec.js
+++ b/spec/mixin_spec.js
@@ -8,12 +8,21 @@ describe('A Model modified using a mixin that defines attributes', function () {
         updated_by: String
       })
 
+  var BooleanAttributesMixin = Mixin('BooleanAttributesMixin')
+      .attributes({
+        enabled: {
+          type: Boolean,
+          initial: false
+        }
+      })
+
   var Person = Model('Person')
       .attributes({
         firstName: String,
         lastName: String
       })
       .use(new LogAttributesMixin())
+      .use(new BooleanAttributesMixin())
 
   it('should be able to configure the augmented attributes', function () {
     var person = new Person({
@@ -33,6 +42,28 @@ describe('A Model modified using a mixin that defines attributes', function () {
     })
 
     expect(person.$clean.updated_by).toEqual('Paul')
+  })
+
+  it('should not modify the attributes definition', function () {
+    var person = new Person({
+      firstName: 'John',
+      lastName: 'Smith',
+      updated_by: 'Paul'
+    })
+
+    var Robot = Model('Robot')
+      .attributes({
+        name: String
+      })
+      .use(new BooleanAttributesMixin())
+
+    var robot = new Robot({
+      name: 'Robotron',
+      enabled: true
+    })
+
+    expect(person.$clean.enabled).toEqual(false)
+    expect(robot.$clean.enabled).toEqual(true)
   })
 })
 

--- a/spec/mixin_spec.js
+++ b/spec/mixin_spec.js
@@ -1,5 +1,41 @@
 /* global describe it expect jasmine */
 
+describe('A Model modified using a mixin that defines attributes', function () {
+  const { Model, Mixin } = require('..')
+
+  var LogAttributesMixin = Mixin('LogAttributesMixin')
+      .attributes({
+        updated_by: String
+      })
+
+  var Person = Model('Person')
+      .attributes({
+        firstName: String,
+        lastName: String
+      })
+      .use(new LogAttributesMixin())
+
+  it('should be able to configure the augmented attributes', function () {
+    var person = new Person({
+      firstName: 'John',
+      lastName: 'Smith',
+      updated_by: 'Paul'
+    })
+
+    expect(person.updated_by).toEqual('Paul')
+  })
+
+  it('should keep the augmented attributes when returning it\'s clean version', function () {
+    var person = new Person({
+      firstName: 'John',
+      lastName: 'Smith',
+      updated_by: 'Paul'
+    })
+
+    expect(person.$clean.updated_by).toEqual('Paul')
+  })
+})
+
 describe('A Model modified using a mixin that defines derived properties', function () {
   const { Model, Mixin } = require('..')
   const mixinSpy = jasmine.createSpy()

--- a/src/attribute.js
+++ b/src/attribute.js
@@ -79,7 +79,6 @@ class Attribute {
   static shorthand (name, options) {
     if (options.hasOwnProperty('type')) {
       let type = options.type
-      delete options.type
       return new Attribute(name, type, options)
     } else {
       return new Attribute(name, options)

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -2,6 +2,7 @@
 
 const $$constructor = Symbol('construct')
 
+const $$attributes = Symbol('attributes')
 const $$derivedProperties = Symbol('derived')
 const $$staticProperties = Symbol('statics')
 const $$findOne = Symbol('find_one')
@@ -42,6 +43,7 @@ function generateMixin (name) {
     }
   }
 
+  klass[$$attributes] = {}
   klass[$$implementations] = []
   klass[$$derivedProperties] = []
   klass[$$staticProperties] = []
@@ -56,6 +58,15 @@ function generateMixin (name) {
   klass.construct = function (fn) {
     if (fn instanceof Function) {
       klass[$$constructor] = fn
+    }
+    return klass
+  }
+
+  klass.attributes = function (attributes) {
+    if (typeof attributes === 'object') {
+      for (const name of Object.keys(attributes)) {
+        klass[$$attributes][name] = attributes[name]
+      }
     }
     return klass
   }
@@ -119,6 +130,7 @@ function generateMixin (name) {
 
   klass.prototype.augmentModel = function (model) {
     if (!this[$$models].has(model)) {
+      augmentWithAttributes(this, model)
       augmentWithDerivedProperties(this, model)
       augmentWithMethods(this, model)
       augmentWithClassMethods(this, model)
@@ -135,6 +147,12 @@ function generateMixin (name) {
       return this[$$models]
     }
   })
+
+  function augmentWithAttributes (mixin, model) {
+    if (Object.keys(klass[$$attributes]).length > 0) {
+      model.attributes(klass[$$attributes])
+    }
+  }
 
   function augmentWithProtocolImplementations (mixin, model) {
     for (let impl of klass[$$implementations]) {


### PR DESCRIPTION
De-duplicate attributes by applying them through mixins:

```javascript
.factory('LogAttributeMixin', function () {
  return Mixin('LogAttributeMixin')
    .attributes({
      updated_date: Date,
      updated_by: String
    })
})```
